### PR TITLE
Fix incorrect return types for enumerateServices and findServices

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -8,8 +8,30 @@ declare module "resin-discoverable-services" {
         port: number;
     }
 
+	export interface ServiceDefinition {
+		service: string;
+		tags: string[];
+	}
+
+	export interface ServiceInformation {
+		addresses: string[];
+		name: string;
+		fqdn: string;
+		host: string;
+		port: number;
+		type: string;
+		protocol: string;
+		subtypes: string[];
+		txt: any;
+		referer: {
+			address: string;
+			family: string;
+			port: number;
+		}
+	}
+
     export function setRegistryPath(path: string): void;
-    export function enumerateServices(callback?: Callback<string[]>): Promise<string[]>;
-    export function findServices(services: string[], timeout?: number, callback?: Callback<string[]>): Promise<string[]>;
+    export function enumerateServices(callback?: Callback<string[]>): Promise<ServiceDefinition[]>;
+    export function findServices(services: string[], timeout?: number, callback?: Callback<ServiceInformation[]>): Promise<ServiceInformation[]>;
     export function publishServices(services: PublishOptions[], callback?: Callback<void>): Promise<void>;
 }


### PR DESCRIPTION
Both `enumerateServices` and `findServices` were incorrectly typed as
returning an array of strings, when they are actually returning arrays
of complex objects.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>