### PR TITLE
Specifically listen on any valid IPv4 interface, to ensure we get responses from all NICs back.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "bluebird": "^3.0.0",
-    "bonjour": "git+https://github.com/resin-io/bonjour.git",
+    "bonjour": "git+https://github.com/resin-io/bonjour#fixed-mdns",
     "ip": "^1.1.4",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION


* Filters responses so there are no duplicates.
* Uses modified `bonjour`->`multicast-dns` branches (experimental) to perform multi-nic listen.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>